### PR TITLE
fix: escape is in html.escape

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ if (sys.version_info[0] < 3):
     import urllib
     import HTMLParser
 else:
-    import html.parser
+    import html
     import urllib.request
     import urllib.parse
 
@@ -28,7 +28,7 @@ def unescape(text):
     if (sys.version_info[0] < 3):
         parser = HTMLParser.HTMLParser()
     else:
-        parser = html.parser.HTMLParser()
+        parser = html
     return (parser.unescape(text))
 
 


### PR DESCRIPTION
`html.parser.HTMLParser.unescape()` has been removed in Python 3.9. `html.unescape` should be used.

> The unescape() method in the html.parser.HTMLParser class has been removed (it was deprecated since Python 3.4). html.unescape() should be used for converting character references to the corresponding unicode characters.

<https://docs.python.org/3/whatsnew/3.9.html?highlight=htmlparser>